### PR TITLE
Use dirname from os.path

### DIFF
--- a/nxstart/utils/files.py
+++ b/nxstart/utils/files.py
@@ -1,6 +1,4 @@
-from distutils import dirname
-
-from os.path import join
+from os.path import join, dirname
 
 PROJECT_ROOT = dirname(dirname(__file__))
 


### PR DESCRIPTION
For some reason distutils doesn't include dirname on my setup (macOS 10.13).

Using the dirname from os.path instead works just fine and shouldn't break anything.